### PR TITLE
build: Unset JAVA env vars to read version

### DIFF
--- a/core/main.mk
+++ b/core/main.mk
@@ -147,8 +147,11 @@ $(warning ************************************************************)
 $(error Directory names containing spaces not supported)
 endif
 
+java_version_str := $(shell unset _JAVA_OPTIONS JAVA_TOOL_OPTIONS && java -version 2>&1)
+javac_version_str := $(shell unset _JAVA_OPTIONS JAVA_TOOL_OPTIONS && javac -version 2>&1)
+
 # Check for the corrent jdk
-ifneq ($(shell java -version 2>&1 | grep -i openjdk),)
+ifneq ($(shell echo '$(java_version_str)' | grep -i openjdk),)
 $(info ************************************************************)
 $(info You are attempting to build with an unsupported JDK.)
 $(info $(space))
@@ -161,8 +164,8 @@ $(info ************************************************************)
 endif
 
 # Check for the correct version of java
-java_version := $(shell java -version 2>&1 | head -n 1 | grep '^java .*[ "]1\.[67][\. "$$]')
-ifneq ($(shell java -version 2>&1 | grep -i openjdk),)
+java_version := $(shell echo '$(java_version_str)' | head -n 1 | grep '^java .*[ "]1\.[67][\. "$$]')
+ifneq ($(shell echo '$(java_version_str)' | grep -i openjdk),)
 java_version :=
 endif
 ifeq ($(strip $(java_version)),)
@@ -170,7 +173,7 @@ $(info ************************************************************)
 $(info You are attempting to build with an unsupported version)
 $(info of java.)
 $(info $(space))
-$(info Your version is: $(shell java -version 2>&1 | head -n 1).)
+$(info Your version is: $(shell echo '$(java_version_str)' | head -n 1).)
 $(info The correct version is: Java SE 1.6 or 1.7.)
 $(info $(space))
 $(info Please follow the machine setup instructions at)
@@ -179,13 +182,13 @@ $(info ************************************************************)
 endif
 
 # Check for the correct version of javac
-javac_version := $(shell javac -version 2>&1 | head -n 1 | grep '[ "]1\.[67][\. "$$]')
+javac_version := $(shell echo '$(javac_version_str)' | head -n 1 | grep '[ "]1\.[67][\. "$$]')
 ifeq ($(strip $(javac_version)),)
 $(info ************************************************************)
 $(info You are attempting to build with the incorrect version)
 $(info of javac.)
 $(info $(space))
-$(info Your version is: $(shell javac -version 2>&1 | head -n 1).)
+$(info Your version is: $(shell echo '$(javac_version_str)' | head -n 1).)
 $(info The correct version is: 1.6 or 1.7.)
 $(info $(space))
 $(info Please follow the machine setup instructions at)


### PR DESCRIPTION
If _JAVA_OPTIONS or JAVA_TOOL_OPTIONS is set, the version is not
correctly parsed from the output of 'java -version'. Unset these
environment variables for the purpose of reading the version.

Change-Id: I8505aac9871e82783b2a35c3a3c894502c24f4b7