### PR TITLE
roomservice: use force-sync when adding projects with roomservice

### DIFF
--- a/tools/roomservice.py
+++ b/tools/roomservice.py
@@ -220,7 +220,7 @@ def fetch_dependencies(repo_path, fallback_branch = None):
 
     if len(syncable_repos) > 0:
         print('Syncing dependencies')
-        os.system('repo sync %s' % ' '.join(syncable_repos))
+        os.system('repo sync --force-sync %s' % ' '.join(syncable_repos))
 
     for deprepo in syncable_repos:
         fetch_dependencies(deprepo)
@@ -282,7 +282,7 @@ else:
             add_to_manifest([adding], fallback_branch)
 
             print("Syncing repository to retrieve project.")
-            os.system('repo sync %s' % repo_path)
+            os.system('repo sync --force-sync %s' % repo_path)
             print("Repository synced!")
 
             fetch_dependencies(repo_path, fallback_branch)


### PR DESCRIPTION
This works around the error
GitError: --force-sync not enabled; cannot overwrite a local work tree
when using roomservice.

Since this should only trigger when the device repos haven't been
checked out yet, we can use force-sync to overwrite any roomservice
device paths in the .repo directory.

Change-Id: Iac54a8a2f2913f82f8ca6497b8785a9d5769640b
Ticket: CYNGNOS-735